### PR TITLE
Add handlebars partials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,31 @@ var result = dummyjson.parse(template, {
 ```
 
 Using your own names and companies will completely override the built-in collections. You can specify just one array, or all of them, as has been done above. **Note:** Names and companies loop when used repeatedly - to keep them in sync the length of the *smallest* array will be used as the loop point. In the example above the `companies` array is smallest and so the final first and last names won't ever appear.
+
+### Using your own partials
+It's even possible to separate your entities/resources in small pieces of code to promote reuse and encapsulation.
+```js
+
+var personTmpl = {
+  "id": {{index}},
+  "firstName": "{{firstName}}",
+  "lastName": "{{lastName}}",
+  "email": "{{email}}",
+  "work": "{{company}}",  
+  "age": {{number 20 50}},
+  "optedin": {{boolean}}
+};
+
+var partials = {
+  person: personTmpl  
+};
+
+var template = {
+  "peoples": [
+    {{#repeat 3}}
+      {{> person }}
+    {{/repeat}}
+  ]
+};
+
+var result = dummyjson.parse(template, {partials: partials});

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ var partials = {
 };
 
 var template = {
-  "peoples": [
+  "people": [
     {{#repeat 3}}
       {{> person }}
     {{/repeat}}

--- a/dummy-json.js
+++ b/dummy-json.js
@@ -166,7 +166,7 @@ module.exports = {
     Handlebars.Utils.extend(combinedHelpers, helpers);
     Handlebars.Utils.extend(combinedHelpers, options.helpers);
 
-    // Registering custom partials if present
+    // Registering partials
     Handlebars.registerPartial(partials);
 
     // Reset indexes on each parse

--- a/dummy-json.js
+++ b/dummy-json.js
@@ -155,6 +155,9 @@ module.exports = {
     lastNames = options.lastNames || _lastNames;
     companies = options.companies || _companies;
 
+    // Adding custom partials
+    partials = options.partials;
+
     // In order to sync the people data we must loop over the smallest array
     maxPersonIndex = Math.min(firstNames.length, lastNames.length, companies.length);
 
@@ -162,6 +165,9 @@ module.exports = {
     var combinedHelpers = {};
     Handlebars.Utils.extend(combinedHelpers, helpers);
     Handlebars.Utils.extend(combinedHelpers, options.helpers);
+
+    // Registering custom partials if present
+    Handlebars.registerPartial(partials);
 
     // Reset indexes on each parse
     uniqueIndex = 0;


### PR DESCRIPTION
I needed to separate several entities/resources structures in different files to proper organization and reuse, so I modified my local copy of dummy-json.js to be able to register Handlebars.partials(). I think that it would be nice if it was available to everyone, since it register partials is one of the main features of Handlebars. 