### PR TITLE
Fix Timezone error on 'time' getDate helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please view the following example on the [github page](https://github.com/webroo
   "users": [
     {{#repeat 2}}
     {
-      "id": {{@index}},
+      "id": {{@id}},
       "name": "{{firstName}} {{lastName}}",
       "work": "{{company}}",
       "email": "{{email}}",
@@ -48,7 +48,7 @@ Please view the following example on the [github page](https://github.com/webroo
 {
   "users": [
     {
-      "id": 0,
+      "id": 1,
       "name": "Adam Carter",
       "work": "Unilogic",
       "email": "adam.carter@unilogic.com",
@@ -58,7 +58,7 @@ Please view the following example on the [github page](https://github.com/webroo
       "optedin": true
     },
     {
-      "id": 1,
+      "id": 2,
       "name": "Leanne Brier",
       "work": "Connic",
       "email": "leanne.brier@connic.org",
@@ -192,7 +192,7 @@ You can omit the comma and line break by using `comma=false`, for example:
 {{#repeat 3 comma=false}}hello{{/repeat}} // hellohellohello
 ```
 
-You can get the iteration position using the standard Handlebars variables `@index`, `@first`, `@last`. The total number of iterations is available using `@total`.
+You can get the iteration position using the standard Handlebars variables `@id`, `@index`, `@first`, `@last`. The total number of iterations is available using `@total`.
 
 ```js
 // Repeat the block 3 times using @index to modify the filename
@@ -720,7 +720,7 @@ You can use Handlebars partials to encapsulate content into a reusable blocks. P
 ```js
 var myPartials = {
   user: '{\
-    "id": {{@index}},\
+    "id": {{@id}},\
     "firstName": "{{firstName}}",\
     "lastName": "{{lastName}}",\
     "email": "{{email}}"\

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -137,6 +137,7 @@ var helpers = {
 
       // You can access these in your template using @index, @total, @first, @last
       data.index = i;
+      data.id = i + 1;
       data.total = total;
       data.first = i === 0;
       data.last = i === total - 1;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -54,13 +54,16 @@ function getDate (type, min, max, format, options) {
   if (format === 'unix') {
     ret = Math.floor(ret.getTime() / 1000);
   } else if (format) {
-    ret = fecha.format(ret, format);
+    ret = fecha.format(convertTimeToUTC(ret), format);
   } else if (type === 'time') {
     // Time has a default format if one is not specified
-    ret = fecha.format(ret, 'HH:mm');
+    ret = fecha.format(convertTimeToUTC(ret), 'HH:mm');
   }
 
   return ret;
+}
+function convertTimeToUTC(d) {
+  return d.setTime(d.getTime() + d.getTimezoneOffset() * 60 * 1000);
 }
 
 function getFirstName (options) {

--- a/test/helpers.spec.js
+++ b/test/helpers.spec.js
@@ -89,6 +89,7 @@ describe('helpers', function () {
         '  {{#repeat 2}}',
         '  {',
         '    "index": {{@index}},',
+        '    "id": {{@id}},',
         '    "total": {{@total}},',
         '    "first": {{@first}},',
         '    "last": {{@last}}',
@@ -99,12 +100,14 @@ describe('helpers', function () {
       var expected = [
         {
           'index': 0,
+          'id': 1,
           'total': 2,
           'first': true,
           'last': false
         },
         {
           'index': 1,
+          'id': 2,
           'total': 2,
           'first': false,
           'last': true


### PR DESCRIPTION
Hi, I'm from Brazil and the test assserts for 'time' helper was failling due to timezone difference (GMT -3).

**Before fix:**

> 77 passing (211ms)
> 2 failing
>   1) helpers time should return different time when used repeatedly:
>       AssertionError: '09:28, 09:19, 06:45' deepEqual '12:28, 12:19, 09:45'
>       + expected - actual
> 
> ```
>   -09:28, 09:19, 06:45
>   +12:28, 12:19, 09:45
> ```
> 
>   2) helpers time should return a time formatted using the format string:
>       AssertionError: '09:28:17' deepEqual '12:28:17'
>       + expected - actual
> 
> ```
>   -09:28:17
>   +12:28:17
> ```

**After fix:**

> 79 passing (186ms)
